### PR TITLE
Initial scaffold for README Improver

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+OPENAI_API_KEY=

--- a/.github/workflows/readme-improver.yml
+++ b/.github/workflows/readme-improver.yml
@@ -1,0 +1,34 @@
+name: "AI README Improver CI"
+
+on:
+  pull_request:
+    paths:
+      - "README.md"
+
+jobs:
+  improve-readme:
+    name: "Analyze README on PR"
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+
+      - name: Install dependencies
+        run: |
+          pip install --upgrade pip
+          pip install openai python-dotenv markdown2
+
+      - name: Load secrets into env
+        run: echo "OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }}" >> $GITHUB_ENV
+
+      - name: Run AI README Improver
+        run: python main.py
+
+      - name: Post feedback as PR comment
+        run: python post_comment.py

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.venv/
+__pycache__/
+.env

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,56 @@
-# ai-readme-improver
-uses ai to improve readme
+# AI README Improver
+
+A CLI tool and GitHub Action that uses OpenAI to analyze and improve `README.md` files. It provides a short TL;DR summary, bullet-point suggestions, and a fully rewritten version of the README.
+
+![demo](https://via.placeholder.com/600x200.png?text=AI+README+Improver+Demo)
+
+## Installation
+
+```bash
+python -m venv .venv
+source .venv/bin/activate  # Windows: .venv\Scripts\activate
+pip install -r requirements.txt
+```
+
+Copy `.env.example` to `.env` and add your `OPENAI_API_KEY`.
+
+## Usage
+
+Run the CLI in the repository that contains a `README.md`:
+
+```bash
+python main.py
+```
+
+The script creates `suggestions.md` and `README.improved.md` with feedback and a polished version of the README.
+
+## GitHub Action Setup
+
+Add the workflow below to `.github/workflows/readme-improver.yml` to automatically post suggestions when a PR modifies `README.md`:
+
+```yaml
+name: "AI README Improver CI"
+on:
+  pull_request:
+    paths: ["README.md"]
+jobs:
+  improve-readme:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+      - run: pip install openai python-dotenv markdown2
+      - run: echo "OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }}" >> $GITHUB_ENV
+      - run: python main.py
+      - run: python post_comment.py
+```
+
+## Contributing
+
+Feel free to open issues or PRs to tweak prompts or add new features.
+
+## License
+
+[MIT](LICENSE)

--- a/improver.py
+++ b/improver.py
@@ -1,0 +1,30 @@
+from openai_helper import ask_openai
+
+def generate_summary(readme_text: str) -> str:
+    prompt = (
+        "You are an AI assistant that reads README files. "
+        "Provide a concise TL;DR summary of the following README (2–3 lines):\n\n"
+        f"{readme_text}"
+    )
+    return ask_openai(prompt, temperature=0.3, max_tokens=200)
+
+def suggest_improvements(readme_text: str) -> str:
+    prompt = (
+        "You are an expert technical writer. "
+        "Suggest specific improvements for this README. "
+        "Mention missing sections (Installation, Usage, License, etc.), "
+        "clarity of language, badge additions, and SEO keywords. "
+        "Output as bullet points:\n\n"
+        f"{readme_text}"
+    )
+    return ask_openai(prompt, temperature=0.5, max_tokens=400)
+
+def rewrite_readme(readme_text: str) -> str:
+    prompt = (
+        "You are an AI that rewrites project README files to be more professional, clear, and complete. "
+        "Rewrite the following README, ensuring it includes these sections: "
+        "Title, Short Description, Installation, Usage, License, Contributing, Contact. "
+        "Use Markdown formatting:\n\n"
+        f"{readme_text}"
+    )
+    return ask_openai(prompt, temperature=0.7, max_tokens=1200)

--- a/main.py
+++ b/main.py
@@ -1,0 +1,46 @@
+import os
+from readme_loader import load_readme
+from improver import generate_summary, suggest_improvements, rewrite_readme
+
+
+def main():
+    readme_path = "README.md"
+    if not os.path.exists(readme_path):
+        print(f"\u274c Error: {readme_path} not found.")
+        return
+
+    readme_text = load_readme(readme_path)
+    if not readme_text.strip():
+        print("\u26a0\ufe0f README is empty. Exiting.")
+        return
+
+    print("\ud83d\udd39 Generating TL;DR summary...")
+    summary = generate_summary(readme_text)
+    print("\n--- TL;DR SUMMARY ---\n")
+    print(summary)
+    print("\n----------------------\n")
+
+    print("\ud83d\udd39 Generating improvement suggestions...")
+    suggestions = suggest_improvements(readme_text)
+    print("\n--- IMPROVEMENT SUGGESTIONS ---\n")
+    print(suggestions)
+    print("\n--------------------------------\n")
+
+    with open("suggestions.md", "w", encoding="utf-8") as f:
+        f.write("# \ud83e\udd16 AI README Improver Feedback\n\n")
+        f.write("## TL;DR Summary\n\n")
+        f.write(summary.strip() + "\n\n")
+        f.write("## Improvement Suggestions\n\n")
+        f.write(suggestions.strip() + "\n\n")
+        f.write("---\n*Powered by [OpenAI](https://openai.com)*\n")
+    print("\u2705 Wrote feedback to suggestions.md")
+
+    print("\ud83d\udd39 Generating rewritten README \u2192 README.improved.md")
+    improved = rewrite_readme(readme_text)
+    with open("README.improved.md", "w", encoding="utf-8") as f:
+        f.write(improved)
+    print("\u2705 Saved improved version to README.improved.md\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/main.py
+++ b/main.py
@@ -1,45 +1,48 @@
 import os
+import sys
 from readme_loader import load_readme
 from improver import generate_summary, suggest_improvements, rewrite_readme
 
 
 def main():
+    sys.stdout.reconfigure(encoding="utf-8")
+
     readme_path = "README.md"
     if not os.path.exists(readme_path):
-        print(f"\u274c Error: {readme_path} not found.")
+        print(f"❌ Error: {readme_path} not found.")
         return
 
     readme_text = load_readme(readme_path)
     if not readme_text.strip():
-        print("\u26a0\ufe0f README is empty. Exiting.")
+        print("⚠️ README is empty. Exiting.")
         return
 
-    print("\ud83d\udd39 Generating TL;DR summary...")
+    print("🔹 Generating TL;DR summary...")
     summary = generate_summary(readme_text)
     print("\n--- TL;DR SUMMARY ---\n")
     print(summary)
     print("\n----------------------\n")
 
-    print("\ud83d\udd39 Generating improvement suggestions...")
+    print("🔹 Generating improvement suggestions...")
     suggestions = suggest_improvements(readme_text)
     print("\n--- IMPROVEMENT SUGGESTIONS ---\n")
     print(suggestions)
     print("\n--------------------------------\n")
 
     with open("suggestions.md", "w", encoding="utf-8") as f:
-        f.write("# \ud83e\udd16 AI README Improver Feedback\n\n")
+        f.write("# 🤖 AI README Improver Feedback\n\n")
         f.write("## TL;DR Summary\n\n")
         f.write(summary.strip() + "\n\n")
         f.write("## Improvement Suggestions\n\n")
         f.write(suggestions.strip() + "\n\n")
         f.write("---\n*Powered by [OpenAI](https://openai.com)*\n")
-    print("\u2705 Wrote feedback to suggestions.md")
+    print("✅ Wrote feedback to suggestions.md")
 
-    print("\ud83d\udd39 Generating rewritten README \u2192 README.improved.md")
+    print("🔹 Generating rewritten README → README.improved.md")
     improved = rewrite_readme(readme_text)
     with open("README.improved.md", "w", encoding="utf-8") as f:
         f.write(improved)
-    print("\u2705 Saved improved version to README.improved.md\n")
+    print("✅ Saved improved version to README.improved.md\n")
 
 
 if __name__ == "__main__":

--- a/openai_helper.py
+++ b/openai_helper.py
@@ -1,0 +1,18 @@
+import os
+import openai
+from dotenv import load_dotenv
+
+load_dotenv()
+
+openai.api_key = os.getenv("OPENAI_API_KEY")
+if openai.api_key is None:
+    raise RuntimeError("OPENAI_API_KEY not set in .env")
+
+def ask_openai(prompt: str, model="gpt-3.5-turbo", temperature=0.5, max_tokens=800) -> str:
+    response = openai.ChatCompletion.create(
+        model=model,
+        messages=[{"role": "user", "content": prompt}],
+        temperature=temperature,
+        max_tokens=max_tokens,
+    )
+    return response.choices[0].message.content.strip()

--- a/post_comment.py
+++ b/post_comment.py
@@ -1,0 +1,46 @@
+import os
+import sys
+import subprocess
+import json
+
+GITHUB_EVENT_PATH = os.getenv("GITHUB_EVENT_PATH")
+GITHUB_TOKEN = os.getenv("GITHUB_TOKEN")
+REPO = os.getenv("GITHUB_REPOSITORY")
+
+
+def get_pr_number() -> str:
+    with open(GITHUB_EVENT_PATH, "r") as f:
+        payload = json.load(f)
+    pr = payload.get("pull_request")
+    if not pr:
+        print("\u274c Not triggered by a pull request. Exiting.")
+        sys.exit(1)
+    return str(pr.get("number"))
+
+
+def main():
+    suggestions_file = "suggestions.md"
+    if not os.path.exists(suggestions_file):
+        print("\u274c suggestions.md not found. Skipping comment.")
+        return
+
+    with open(suggestions_file, "r", encoding="utf-8") as f:
+        body = f.read().strip()
+
+    pr_number = get_pr_number()
+
+    cmd = [
+        "gh", "issue", "comment", pr_number,
+        "--repo", REPO,
+        "--body", body
+    ]
+    print(f"Posting feedback to PR #{pr_number}...")
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        print("\u274c Failed to post comment:", result.stderr)
+    else:
+        print("\u2705 Feedback posted successfully.")
+
+
+if __name__ == "__main__":
+    main()

--- a/post_comment.py
+++ b/post_comment.py
@@ -13,7 +13,7 @@ def get_pr_number() -> str:
         payload = json.load(f)
     pr = payload.get("pull_request")
     if not pr:
-        print("\u274c Not triggered by a pull request. Exiting.")
+        print("❌ Not triggered by a pull request. Exiting.")
         sys.exit(1)
     return str(pr.get("number"))
 
@@ -21,7 +21,7 @@ def get_pr_number() -> str:
 def main():
     suggestions_file = "suggestions.md"
     if not os.path.exists(suggestions_file):
-        print("\u274c suggestions.md not found. Skipping comment.")
+        print("❌ suggestions.md not found. Skipping comment.")
         return
 
     with open(suggestions_file, "r", encoding="utf-8") as f:
@@ -37,9 +37,9 @@ def main():
     print(f"Posting feedback to PR #{pr_number}...")
     result = subprocess.run(cmd, capture_output=True, text=True)
     if result.returncode != 0:
-        print("\u274c Failed to post comment:", result.stderr)
+        print("❌ Failed to post comment:", result.stderr)
     else:
-        print("\u2705 Feedback posted successfully.")
+        print("✅ Feedback posted successfully.")
 
 
 if __name__ == "__main__":

--- a/readme_loader.py
+++ b/readme_loader.py
@@ -1,0 +1,7 @@
+def load_readme(path="README.md") -> str:
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            return f.read()
+    except FileNotFoundError:
+        print(f"Error: {path} not found.")
+        return ""

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+openai
+python-dotenv
+markdown2


### PR DESCRIPTION
## Summary
- ignore venv and dotenv files
- add MIT license and requirements
- add modules for loading README, OpenAI helper, and improvements
- provide CLI script to generate suggestions
- include helper for posting PR comments
- document setup and GitHub Action
- add CI workflow to run on README changes

## Testing
- `python -m py_compile readme_loader.py openai_helper.py improver.py main.py post_comment.py`

------
https://chatgpt.com/codex/tasks/task_e_68424f715ac08330af2ba094cdecfca0