### PR TITLE
Improve README improver CLI usability

### DIFF
--- a/.github/workflows/readme-improver.yml
+++ b/.github/workflows/readme-improver.yml
@@ -22,7 +22,8 @@ jobs:
       - name: Install dependencies
         run: |
           pip install --upgrade pip
-          pip install openai python-dotenv markdown2
+          # Pin OpenAI to 0.28 for compatibility with this project
+          pip install openai==0.28 python-dotenv markdown2
 
       - name: Load secrets into env
         run: echo "OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }}" >> $GITHUB_ENV

--- a/README.md
+++ b/README.md
@@ -16,13 +16,28 @@ Copy `.env.example` to `.env` and add your `OPENAI_API_KEY`.
 
 ## Usage
 
-Run the CLI in the repository that contains a `README.md`:
+The CLI can analyse the `README.md` in the current directory or any other folder.
 
-```bash
-python main.py
-```
+1. **Activate your environment** (if not already):
 
-The script creates `suggestions.md` and `README.improved.md` with feedback and a polished version of the README.
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate  # Windows: .venv\Scripts\activate
+   pip install -r requirements.txt
+   ```
+
+2. **Set your OpenAI API key** by copying `.env.example` to `.env` and filling
+   in `OPENAI_API_KEY`.
+
+3. **Run the CLI**:
+
+   ```bash
+   python main.py            # analyse README.md in the current directory
+   python main.py path/to/project  # or point to another folder
+   python main.py /path/to/README.md  # or a specific file
+   ```
+
+The script creates `suggestions.md` and `README.improved.md` next to the target README.
 
 ## GitHub Action Setup
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ source .venv/bin/activate  # Windows: .venv\Scripts\activate
 pip install -r requirements.txt
 ```
 
+`requirements.txt` pins the `openai` package to version `0.28` for
+compatibility with the scripts in this repository.
+
 Copy `.env.example` to `.env` and add your `OPENAI_API_KEY`.
 
 ## Usage
@@ -56,7 +59,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: "3.10"
-      - run: pip install openai python-dotenv markdown2
+      - run: pip install openai==0.28 python-dotenv markdown2
       - run: echo "OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }}" >> $GITHUB_ENV
       - run: python main.py
       - run: python post_comment.py

--- a/improver.py
+++ b/improver.py
@@ -1,6 +1,10 @@
+"""Functions that interact with OpenAI to analyse and rewrite README files."""
+
 from openai_helper import ask_openai
 
 def generate_summary(readme_text: str) -> str:
+    """Return a short TL;DR summary of ``readme_text`` using OpenAI."""
+
     prompt = (
         "You are an AI assistant that reads README files. "
         "Provide a concise TL;DR summary of the following README (2–3 lines):\n\n"
@@ -9,6 +13,8 @@ def generate_summary(readme_text: str) -> str:
     return ask_openai(prompt, temperature=0.3, max_tokens=200)
 
 def suggest_improvements(readme_text: str) -> str:
+    """Return bullet-point suggestions to enhance ``readme_text``."""
+
     prompt = (
         "You are an expert technical writer. "
         "Suggest specific improvements for this README. "
@@ -20,6 +26,8 @@ def suggest_improvements(readme_text: str) -> str:
     return ask_openai(prompt, temperature=0.5, max_tokens=400)
 
 def rewrite_readme(readme_text: str) -> str:
+    """Return a rewritten version of ``readme_text`` with common sections."""
+
     prompt = (
         "You are an AI that rewrites project README files to be more professional, clear, and complete. "
         "Rewrite the following README, ensuring it includes these sections: "
@@ -28,3 +36,4 @@ def rewrite_readme(readme_text: str) -> str:
         f"{readme_text}"
     )
     return ask_openai(prompt, temperature=0.7, max_tokens=1200)
+

--- a/main.py
+++ b/main.py
@@ -1,13 +1,42 @@
+"""Command line interface for the AI README Improver."""
+
+import argparse
 import os
 import sys
+
 from readme_loader import load_readme
 from improver import generate_summary, suggest_improvements, rewrite_readme
 
 
-def main():
+def main() -> None:
+    """Run the CLI to analyze and improve a README file."""
+
+    # Ensure unicode characters (like emojis) print correctly on all platforms
     sys.stdout.reconfigure(encoding="utf-8")
 
-    readme_path = "README.md"
+    parser = argparse.ArgumentParser(
+        description=(
+            "Generate a summary, suggestions and an improved version of a README"
+        )
+    )
+    parser.add_argument(
+        "path",
+        nargs="?",
+        default=".",
+        help=(
+            "Path to a README.md file or a folder containing one. Defaults to the"
+            " current directory"
+        ),
+    )
+    args = parser.parse_args()
+
+    # Allow passing either a README file or a folder containing it
+    target_path = args.path
+    if os.path.isdir(target_path):
+        readme_path = os.path.join(target_path, "README.md")
+    else:
+        readme_path = target_path
+
     if not os.path.exists(readme_path):
         print(f"❌ Error: {readme_path} not found.")
         return
@@ -29,7 +58,9 @@ def main():
     print(suggestions)
     print("\n--------------------------------\n")
 
-    with open("suggestions.md", "w", encoding="utf-8") as f:
+    output_dir = os.path.dirname(readme_path) or "."
+
+    with open(os.path.join(output_dir, "suggestions.md"), "w", encoding="utf-8") as f:
         f.write("# 🤖 AI README Improver Feedback\n\n")
         f.write("## TL;DR Summary\n\n")
         f.write(summary.strip() + "\n\n")
@@ -40,10 +71,11 @@ def main():
 
     print("🔹 Generating rewritten README → README.improved.md")
     improved = rewrite_readme(readme_text)
-    with open("README.improved.md", "w", encoding="utf-8") as f:
+    with open(os.path.join(output_dir, "README.improved.md"), "w", encoding="utf-8") as f:
         f.write(improved)
     print("✅ Saved improved version to README.improved.md\n")
 
 
 if __name__ == "__main__":
     main()
+

--- a/openai_helper.py
+++ b/openai_helper.py
@@ -1,14 +1,27 @@
+"""Helper utilities for sending prompts to OpenAI."""
+
 import os
 import openai
 from dotenv import load_dotenv
 
+# ``python-dotenv`` loads variables from a .env file so the API key can be
+# stored locally without hard coding it into the script.
 load_dotenv()
 
+# Read the API key from the environment. ``load_dotenv`` above will populate
+# it from a ``.env`` file if present.
 openai.api_key = os.getenv("OPENAI_API_KEY")
 if openai.api_key is None:
     raise RuntimeError("OPENAI_API_KEY not set in .env")
 
-def ask_openai(prompt: str, model="gpt-3.5-turbo", temperature=0.5, max_tokens=800) -> str:
+def ask_openai(
+    prompt: str,
+    model: str = "gpt-3.5-turbo",
+    temperature: float = 0.5,
+    max_tokens: int = 800,
+) -> str:
+    """Send ``prompt`` to OpenAI and return the response text."""
+
     response = openai.ChatCompletion.create(
         model=model,
         messages=[{"role": "user", "content": prompt}],
@@ -16,3 +29,5 @@ def ask_openai(prompt: str, model="gpt-3.5-turbo", temperature=0.5, max_tokens=8
         max_tokens=max_tokens,
     )
     return response.choices[0].message.content.strip()
+
+

--- a/post_comment.py
+++ b/post_comment.py
@@ -1,3 +1,5 @@
+"""GitHub Action helper to post README suggestions as a pull request comment."""
+
 import os
 import sys
 import subprocess
@@ -9,6 +11,8 @@ REPO = os.getenv("GITHUB_REPOSITORY")
 
 
 def get_pr_number() -> str:
+    """Extract the pull request number from the GitHub Actions event file."""
+
     with open(GITHUB_EVENT_PATH, "r") as f:
         payload = json.load(f)
     pr = payload.get("pull_request")
@@ -19,6 +23,8 @@ def get_pr_number() -> str:
 
 
 def main():
+    """Post the contents of ``suggestions.md`` as a PR comment using ``gh``."""
+
     suggestions_file = "suggestions.md"
     if not os.path.exists(suggestions_file):
         print("❌ suggestions.md not found. Skipping comment.")
@@ -44,3 +50,4 @@ def main():
 
 if __name__ == "__main__":
     main()
+

--- a/readme_loader.py
+++ b/readme_loader.py
@@ -1,5 +1,12 @@
-def load_readme(path="README.md") -> str:
+"""Utility for loading README files."""
+
+
+def load_readme(path: str = "README.md") -> str:
+    """Return the contents of ``path`` or an empty string if it doesn't exist."""
+
     try:
+        # ``encoding='utf-8'`` allows reading files with emojis or other
+        # non-ascii characters without errors.
         with open(path, "r", encoding="utf-8") as f:
             return f.read()
     except FileNotFoundError:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-openai
+openai==0.28
 python-dotenv
 markdown2


### PR DESCRIPTION
## Summary
- add CLI argument to specify README path
- write beginner-friendly instructions in README
- document helper modules with comments

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6842567694e0833083dda436ffe9b932