### PR TITLE
Add detailed logging for OpenAI calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .venv/
 __pycache__/
 .env
+logs/

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ python main.py
 
 The script creates `suggestions.md` and `README.improved.md` with feedback and a polished version of the README.
 
+Detailed logs for each run are written to `logs/run_YYYYMMDD_HHMMSS.log`. These logs include the prompts sent to OpenAI, the responses, token usage, estimated cost and timing information.
+
 ## GitHub Action Setup
 
 Add the workflow below to `.github/workflows/readme-improver.yml` to automatically post suggestions when a PR modifies `README.md`:

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ pip install -r requirements.txt
 ```
 
 Copy `.env.example` to `.env` and add your `OPENAI_API_KEY`.
+The script exits with an error if this variable is not set.
 
 ## Usage
 

--- a/logger.py
+++ b/logger.py
@@ -1,0 +1,32 @@
+import logging
+import os
+from datetime import datetime
+
+_logger = None
+
+def get_logger():
+    global _logger
+    if _logger:
+        return _logger
+
+    logs_dir = "logs"
+    os.makedirs(logs_dir, exist_ok=True)
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    log_file = os.path.join(logs_dir, f"run_{timestamp}.log")
+
+    logger = logging.getLogger("readme_improver")
+    logger.setLevel(logging.INFO)
+    logger.propagate = False
+
+    formatter = logging.Formatter("%(asctime)s - %(message)s", "%H:%M:%S")
+
+    file_handler = logging.FileHandler(log_file, encoding="utf-8")
+    file_handler.setFormatter(formatter)
+    logger.addHandler(file_handler)
+
+    console_handler = logging.StreamHandler()
+    console_handler.setFormatter(formatter)
+    logger.addHandler(console_handler)
+
+    _logger = logger
+    return logger

--- a/main.py
+++ b/main.py
@@ -10,6 +10,10 @@ logger = get_logger()
 def main():
     sys.stdout.reconfigure(encoding="utf-8")
 
+    if not os.getenv("OPENAI_API_KEY"):
+        logger.error("OPENAI_API_KEY is not set. Add it to your .env file.")
+        return
+
     readme_path = "README.md"
     if not os.path.exists(readme_path):
         logger.error(f"❌ Error: {readme_path} not found.")

--- a/main.py
+++ b/main.py
@@ -2,6 +2,9 @@ import os
 import sys
 from readme_loader import load_readme
 from improver import generate_summary, suggest_improvements, rewrite_readme
+from logger import get_logger
+
+logger = get_logger()
 
 
 def main():
@@ -9,25 +12,25 @@ def main():
 
     readme_path = "README.md"
     if not os.path.exists(readme_path):
-        print(f"❌ Error: {readme_path} not found.")
+        logger.error(f"❌ Error: {readme_path} not found.")
         return
 
     readme_text = load_readme(readme_path)
     if not readme_text.strip():
-        print("⚠️ README is empty. Exiting.")
+        logger.warning("⚠️ README is empty. Exiting.")
         return
 
-    print("🔹 Generating TL;DR summary...")
+    logger.info("🔹 Generating TL;DR summary...")
     summary = generate_summary(readme_text)
-    print("\n--- TL;DR SUMMARY ---\n")
-    print(summary)
-    print("\n----------------------\n")
+    logger.info("\n--- TL;DR SUMMARY ---\n")
+    logger.info(summary)
+    logger.info("\n----------------------\n")
 
-    print("🔹 Generating improvement suggestions...")
+    logger.info("🔹 Generating improvement suggestions...")
     suggestions = suggest_improvements(readme_text)
-    print("\n--- IMPROVEMENT SUGGESTIONS ---\n")
-    print(suggestions)
-    print("\n--------------------------------\n")
+    logger.info("\n--- IMPROVEMENT SUGGESTIONS ---\n")
+    logger.info(suggestions)
+    logger.info("\n--------------------------------\n")
 
     with open("suggestions.md", "w", encoding="utf-8") as f:
         f.write("# 🤖 AI README Improver Feedback\n\n")
@@ -36,13 +39,13 @@ def main():
         f.write("## Improvement Suggestions\n\n")
         f.write(suggestions.strip() + "\n\n")
         f.write("---\n*Powered by [OpenAI](https://openai.com)*\n")
-    print("✅ Wrote feedback to suggestions.md")
+    logger.info("✅ Wrote feedback to suggestions.md")
 
-    print("🔹 Generating rewritten README → README.improved.md")
+    logger.info("🔹 Generating rewritten README → README.improved.md")
     improved = rewrite_readme(readme_text)
     with open("README.improved.md", "w", encoding="utf-8") as f:
         f.write(improved)
-    print("✅ Saved improved version to README.improved.md\n")
+    logger.info("✅ Saved improved version to README.improved.md\n")
 
 
 if __name__ == "__main__":

--- a/openai_helper.py
+++ b/openai_helper.py
@@ -1,6 +1,10 @@
 import os
+import time
 from dotenv import load_dotenv
 from openai import OpenAI
+from logger import get_logger
+
+logger = get_logger()
 
 load_dotenv()
 
@@ -10,11 +14,43 @@ if api_key is None:
 
 client = OpenAI(api_key=api_key)
 
+# Rough USD cost per 1K tokens for supported models
+MODEL_COST_PER_1K = {
+    "gpt-3.5-turbo": 0.002,
+}
+
+
+def _estimate_cost(model: str, total_tokens: int) -> float:
+    price = MODEL_COST_PER_1K.get(model, 0)
+    return (total_tokens / 1000) * price
+
 def ask_openai(prompt: str, model="gpt-3.5-turbo", temperature=0.5, max_tokens=800) -> str:
+    logger.info("\n----- OpenAI Request -----")
+    logger.info(f"Model: {model} | Temperature: {temperature} | Max tokens: {max_tokens}")
+    logger.info("Prompt:\n" + prompt)
+
+    start = time.time()
     response = client.chat.completions.create(
         model=model,
         messages=[{"role": "user", "content": prompt}],
         temperature=temperature,
         max_tokens=max_tokens,
     )
-    return response.choices[0].message.content.strip()
+    elapsed = time.time() - start
+
+    content = response.choices[0].message.content.strip()
+    usage = response.usage
+    if usage:
+        cost = _estimate_cost(model, usage.total_tokens)
+        logger.info(
+            f"Tokens: prompt={usage.prompt_tokens} completion={usage.completion_tokens} "
+            f"total={usage.total_tokens}"
+        )
+        logger.info(f"Estimated cost: ${cost:.6f}")
+    else:
+        logger.info("Token usage unavailable")
+    logger.info(f"Elapsed time: {elapsed:.2f}s")
+    logger.info("Response:\n" + content)
+    logger.info("----- End Request -----\n")
+
+    return content


### PR DESCRIPTION
## Summary
- create `logger.py` utility for file+console logging
- log prompts, responses, token usage and estimated cost
- add rich logs in `main.py`
- store logs in `logs/` and ignore that folder
- document logging in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -r requirements.txt`
- `OPENAI_API_KEY=dummy python main.py` *(fails: openai.AuthenticationError)*

------
https://chatgpt.com/codex/tasks/task_e_68425dccd3cc8330b55155404d50c4e9