### PR TITLE
Upload README logs as GitHub artifact

### DIFF
--- a/.github/workflows/readme-improver.yml
+++ b/.github/workflows/readme-improver.yml
@@ -60,3 +60,9 @@ jobs:
           git add README.md
           git commit -m "🤖 Auto-improved README using AI"
           git push origin HEAD:${{ github.head_ref }}
+
+      - name: Upload logs artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: readme-improver-logs
+          path: logs

--- a/.github/workflows/readme-improver.yml
+++ b/.github/workflows/readme-improver.yml
@@ -62,7 +62,7 @@ jobs:
           git push origin HEAD:${{ github.head_ref }}
 
       - name: Upload logs artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: readme-improver-logs
           path: logs

--- a/README.improved.md
+++ b/README.improved.md
@@ -48,7 +48,7 @@ jobs:
       - run: pip install "openai>=1.0" python-dotenv markdown2
       - run: echo "OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }}" >> $GITHUB_ENV
       - run: python main.py
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: readme-improver-logs
           path: logs

--- a/README.improved.md
+++ b/README.improved.md
@@ -26,7 +26,7 @@ python main.py
 
 Upon running the script, two additional files, `suggestions.md` and `README.improved.md`, will be generated, offering feedback and an enhanced version of the README.
 
-Comprehensive logs for each execution are stored in `logs/run_YYYYMMDD_HHMMSS.log`, capturing OpenAI prompts, responses, token usage, estimated costs, and timing details.
+Comprehensive logs for each execution are stored in `logs/run_YYYYMMDD_HHMMSS.log`, capturing OpenAI prompts, responses, token usage, estimated costs, and timing details. When run in GitHub Actions, these logs are uploaded as an artifact for later download.
 
 ## GitHub Action Setup
 
@@ -48,6 +48,10 @@ jobs:
       - run: pip install "openai>=1.0" python-dotenv markdown2
       - run: echo "OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }}" >> $GITHUB_ENV
       - run: python main.py
+      - uses: actions/upload-artifact@v3
+        with:
+          name: readme-improver-logs
+          path: logs
       - run: python post_comment.py
 ```
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ jobs:
       - run: pip install "openai>=1.0" python-dotenv markdown2
       - run: echo "OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }}" >> $GITHUB_ENV
       - run: python main.py
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: readme-improver-logs
           path: logs

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ python main.py
 
 Upon running the script, two additional files, `suggestions.md` and `README.improved.md`, will be generated, offering feedback and an enhanced version of the README.
 
-Comprehensive logs for each execution are stored in `logs/run_YYYYMMDD_HHMMSS.log`, capturing OpenAI prompts, responses, token usage, estimated costs, and timing details.
+Comprehensive logs for each execution are stored in `logs/run_YYYYMMDD_HHMMSS.log`, capturing OpenAI prompts, responses, token usage, estimated costs, and timing details. When run in GitHub Actions, these logs are uploaded as an artifact for later download.
 
 ## GitHub Action Setup
 
@@ -48,6 +48,10 @@ jobs:
       - run: pip install "openai>=1.0" python-dotenv markdown2
       - run: echo "OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }}" >> $GITHUB_ENV
       - run: python main.py
+      - uses: actions/upload-artifact@v3
+        with:
+          name: readme-improver-logs
+          path: logs
       - run: python post_comment.py
 ```
 


### PR DESCRIPTION
## Summary
- save workflow logs to an artifact so they aren't lost
- document the new artifact upload step in the README files

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_684279c2aad883308596024d68a30cc2