### PR TITLE
Fix README auto-update workflow

### DIFF
--- a/.github/workflows/readme-improver.yml
+++ b/.github/workflows/readme-improver.yml
@@ -1,11 +1,14 @@
 name: "AI README Improver"
 
 on:
+  pull_request:
+    paths: ["README.md"]
   push:
     branches: [main]
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   update-readme:
@@ -14,6 +17,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-python@v4
         with:
@@ -25,7 +30,8 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: python main.py
 
-      - run: |
+      - name: Replace README with improved version
+        run: |
           mv README.improved.md README.md
           rm suggestions.md
 
@@ -35,4 +41,10 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add README.md
           git diff --cached --quiet || git commit -m "Auto update README"
-          git push origin HEAD:main
+          git push origin HEAD:${{ github.head_ref || github.ref_name }}
+
+      - name: Comment on PR with suggestions
+        if: github.event_name == 'pull_request'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python post_comment.py


### PR DESCRIPTION
## Summary
- run the README improver when a PR changes `README.md`
- commit the updated README back to the PR branch or to `main`
- post suggestions as a PR comment

## Testing
- `pre-commit run --files .github/workflows/readme-improver.yml`


------
https://chatgpt.com/codex/tasks/task_e_684285a1cd548330b72b4f0e356db58a