### PR TITLE
Add config support and CLI overrides

### DIFF
--- a/.github/workflows/readme-improver.yml
+++ b/.github/workflows/readme-improver.yml
@@ -26,9 +26,14 @@ jobs:
 
       - run: pip install -r requirements.txt
 
-      - env:
+      - name: Run AI README Improver
+        env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-        run: python main.py
+        run: |
+          python main.py \
+            --config config.yaml \
+            --email "${{ secrets.README_EMAIL }}" \
+            --logo-path "assets/logo.png"
 
       - name: Replace README with improved version
         run: |

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,15 @@
+project_name: "AI README Improver"
+email: "you@example.com"
+logo_path: "assets/logo.png"
+badges:
+  - name: "Build Status"
+    image_url: "https://img.shields.io/github/actions/workflow/status/username/repo/ci.yml"
+    link: "https://github.com/username/repo/actions"
+extra_sections:
+  - title: "Maintainers"
+    content: |
+      - Alice Johnson (@alicej)
+      - Bob Smith (@bobsmith)
+  - title: "Acknowledgements"
+    content: |
+      Thanks to OpenAI and the community for feedback.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
 openai>=1.0
 python-dotenv
 markdown2
+
+PyYAML>=6.0
+jinja2>=3.0


### PR DESCRIPTION
## Summary
- add sample `config.yaml`
- install PyYAML and Jinja2 in requirements
- implement `load_config`, `build_prompt` and pass config to `rewrite_readme`
- add CLI options for config overrides and interactive mode
- update workflow to pass email and logo path

## Testing
- `python -m py_compile improver.py main.py`
- `pre-commit run --files config.yaml requirements.txt improver.py main.py .github/workflows/readme-improver.yml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68429261c3788330aaa3da507c2f1f32