### PR TITLE
Refactor modules and expand tests

### DIFF
--- a/improver.py
+++ b/improver.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
 import os
+from typing import Any
+
 import yaml
-from jinja2 import Environment, FileSystemLoader
 
 from openai_helper import ask_openai
 
 
-def load_config(path: str = "config.yaml") -> dict:
+def load_config(path: str = "config.yaml") -> dict[str, Any]:
     """Load configuration values from a YAML file.
 
     Args:
@@ -24,7 +25,7 @@ def load_config(path: str = "config.yaml") -> dict:
         return yaml.safe_load(f)
 
 
-def build_prompt(readme_text: str, config: dict) -> str:
+def build_prompt(readme_text: str, config: dict[str, Any]) -> str:
     """Construct the prompt for the rewrite request.
 
     Args:
@@ -43,9 +44,10 @@ def build_prompt(readme_text: str, config: dict) -> str:
     if config.get("email"):
         contact_section = f"## Contact\n- Email: {config['email']}"
 
-    extra_sections_md = ""
-    for section in config.get("extra_sections", []):
-        extra_sections_md += f"## {section['title']}\n{section['content']}\n\n"
+    sections = [
+        f"## {s['title']}\n{s['content']}\n" for s in config.get("extra_sections", [])
+    ]
+    extra_sections_md = "\n".join(sections)
 
     return f"""
 You are ChatGPT. Improve the project's README.md with these rules:

--- a/logger.py
+++ b/logger.py
@@ -2,19 +2,21 @@ import logging
 import os
 from datetime import datetime
 
+LOG_DIR = "logs"
+
 _logger = None
+
 
 def get_logger() -> logging.Logger:
     """Return a configured logger writing to file and console."""
 
     global _logger
-    if _logger:
+    if _logger is not None:
         return _logger
 
-    logs_dir = "logs"
-    os.makedirs(logs_dir, exist_ok=True)
+    os.makedirs(LOG_DIR, exist_ok=True)
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-    log_file = os.path.join(logs_dir, f"run_{timestamp}.log")
+    log_file = os.path.join(LOG_DIR, f"run_{timestamp}.log")
 
     logger = logging.getLogger("readme_improver")
     logger.setLevel(logging.INFO)

--- a/readme_loader.py
+++ b/readme_loader.py
@@ -1,3 +1,9 @@
+from logger import get_logger
+
+
+logger = get_logger()
+
+
 def load_readme(path: str = "README.md") -> str:
     """Load the contents of a README file.
 
@@ -6,12 +12,12 @@ def load_readme(path: str = "README.md") -> str:
 
     Returns:
         The file contents as a string. If the file is missing, an empty
-        string is returned and an error message is printed.
+        string is returned and an error message is logged.
     """
 
     try:
         with open(path, "r", encoding="utf-8") as f:
             return f.read()
     except FileNotFoundError:
-        print(f"Error: {path} not found.")
+        logger.error("%s not found.", path)
         return ""

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1,0 +1,70 @@
+import os
+from pathlib import Path
+
+import openai_helper
+from logger import get_logger
+from improver import load_config, build_prompt
+
+
+class DummyClient:
+    def __init__(self, text="ok"):
+        self.text = text
+        self.calls = 0
+        self.chat = self
+        self.completions = self
+
+    def create(self, model, messages, temperature, max_tokens):
+        self.calls += 1
+
+        class R:
+            choices = [
+                type(
+                    "C",
+                    (),
+                    {
+                        "message": type("M", (), {"content": self.text})(),
+                        "finish_reason": "stop",
+                    },
+                )
+            ]
+            usage = type(
+                "U", (), {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2}
+            )
+
+        return R()
+
+
+def test_build_prompt():
+    cfg = {
+        "logo_path": "logo.png",
+        "email": "a@b.com",
+        "extra_sections": [{"title": "More", "content": "Stuff"}],
+    }
+    prompt = build_prompt("readme", cfg)
+    assert "logo.png" in prompt
+    assert "## Contact" in prompt
+    assert "More" in prompt
+
+
+def test_load_config(tmp_path):
+    p = tmp_path / "cfg.yaml"
+    p.write_text("a: 1", encoding="utf-8")
+    assert load_config(str(p)) == {"a": 1}
+    assert load_config(str(tmp_path / "missing.yaml")) == {}
+
+
+def test_get_logger_singleton():
+    l1 = get_logger()
+    l2 = get_logger()
+    assert l1 is l2
+
+
+def test_ask_openai_caching(tmp_path, monkeypatch):
+    dummy = DummyClient("answer")
+    monkeypatch.setattr(openai_helper, "_get_client", lambda: dummy)
+    monkeypatch.setattr(openai_helper, "CACHE_DIR", Path(tmp_path))
+    result1 = openai_helper.ask_openai("hi", model="test")
+    result2 = openai_helper.ask_openai("hi", model="test")
+    assert result1 == "answer"
+    assert result2 == "answer"
+    assert dummy.calls == 1


### PR DESCRIPTION
## Summary
- cleanup imports and type hints in `improver`
- centralize log path handling in `logger`
- rename cache and client fields in `openai_helper`
- log missing README errors instead of printing in `readme_loader`
- add tests for misc utilities and OpenAI helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843669061e08330a65cdd591f65e040