### PR TITLE
Fix markdownlint step

### DIFF
--- a/.github/workflows/auto-docs.yml
+++ b/.github/workflows/auto-docs.yml
@@ -13,7 +13,14 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.10'
-      - run: pip install -r requirements.txt
+      - name: Set up Node.js (for markdownlint)
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+          npm install -g markdownlint-cli
       - run: markdownlint README.md docs/**/*.md
       - run: linkchecker README.md
       - run: python scripts/update_readme.py


### PR DESCRIPTION
## Summary
- set up Node.js in auto-docs workflow
- globally install markdownlint-cli before running it

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684368e12d488330a79691b739ae911f