### PR TITLE
Add stricter prompt for README rewrite

### DIFF
--- a/improver.py
+++ b/improver.py
@@ -58,6 +58,7 @@ You are ChatGPT. Improve the project's README.md with these rules:
 3. Ensure a “Contact” section with the email is at the bottom:
    {contact_section}
 4. Provide a short TL;DR summary and bullet-point suggestions, then output the fully-rewritten README.md.
+5. Only use maintainer names and other details explicitly provided in the config or current README. Do not invent additional data.
 
 Here is the current README.md:
 {readme_text}


### PR DESCRIPTION
## Summary
- avoid invented maintainer names in improved README by updating rewrite prompt

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68453262815c8330a84123fe3b629160