### PR TITLE
Fix workflow cleanup and outputs

### DIFF
--- a/.github/workflows/auto-docs.yml
+++ b/.github/workflows/auto-docs.yml
@@ -24,6 +24,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -r requirements.txt
+          pip install linkchecker
           npm install -g markdownlint-cli
       - name: Lint Markdown files
         run: markdownlint README.md docs/**/*.md
@@ -38,7 +39,7 @@ jobs:
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
           timestamp=$(date -u +"%Y-%m-%d-%H-%M")
-          git add README.md SUGGESTED_README.md README_SUGGESTIONS.md oldreadme/ || true
+          git add README.md README.improved.md suggestions.md oldreadme/ || true
           git status --short
           if git diff --cached --quiet; then
             echo "No changes to commit"

--- a/.github/workflows/readme-improver.yml
+++ b/.github/workflows/readme-improver.yml
@@ -36,25 +36,32 @@ jobs:
 
       - run: pip install -r requirements.txt
 
+      - name: Set archive timestamp
+        run: echo "TIMESTAMP=$(date -u +'%Y-%m-%d-%H-%M')" >> $GITHUB_ENV
+
       - name: Run AI README Improver
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
           python run_improver.py \
-            --config config.yaml \
+            --config readme-improver.config.yaml \
             --email "${{ github.event.inputs.email || secrets.README_EMAIL }}" \
             --logo-path "${{ github.event.inputs.logo-path || 'assets/logo.png' }}"
 
-      - name: Replace README with improved version
+      - name: Archive README and apply improvements
         run: |
-          mv README.improved.md README.md
-          rm -f suggestions.md
+          mkdir -p oldreadme/$TIMESTAMP
+          if [ -f README.md ]; then
+            cp README.md "oldreadme/$TIMESTAMP/README.md"
+          fi
+          cp suggestions.md "oldreadme/$TIMESTAMP/suggestions.md"
+          cp README.improved.md README.md
 
       - name: Commit and push updated README
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add README.md
+          git add README.md README.improved.md suggestions.md oldreadme/ || true
           git diff --cached --quiet || git commit -m "Auto update README"
           git push origin HEAD:${{ github.head_ref || github.ref_name }}
 
@@ -63,3 +70,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: python post_comment.py
+
+      - name: Clean up suggestion file
+        if: github.event_name == 'pull_request'
+        run: rm -f suggestions.md

--- a/scripts/update_readme.py
+++ b/scripts/update_readme.py
@@ -22,7 +22,7 @@ def archive_previous(timestamp: str) -> Path:
     """Move existing generated files into a timestamped archive directory."""
     archive_dir = ARCHIVE_ROOT / timestamp
     archive_dir.mkdir(parents=True, exist_ok=True)
-    for name in ["README.md", "SUGGESTED_README.md", "README_SUGGESTIONS.md"]:
+    for name in ["README.md", "README.improved.md", "suggestions.md"]:
         path = Path(name)
         if path.exists():
             shutil.move(str(path), archive_dir / path.name)
@@ -35,7 +35,7 @@ def generate_files(readme_text: str, cfg: dict) -> None:
     suggestions = suggest_improvements(readme_text)
     improved = rewrite_readme(readme_text, config=cfg)
 
-    Path("SUGGESTED_README.md").write_text(improved, encoding="utf-8")
+    Path("README.improved.md").write_text(improved, encoding="utf-8")
     Path("README.md").write_text(improved, encoding="utf-8")
 
     suggestion_content = (
@@ -46,7 +46,7 @@ def generate_files(readme_text: str, cfg: dict) -> None:
         f"{suggestions}\n\n"
         "---\n*Powered by [OpenAI](https://openai.com)*\n"
     )
-    Path("README_SUGGESTIONS.md").write_text(suggestion_content, encoding="utf-8")
+    Path("suggestions.md").write_text(suggestion_content, encoding="utf-8")
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary
- archive README and suggestion artifacts in workflow
- keep suggestions until after PR comment
- install linkchecker in auto-docs workflow
- standardize generated filenames

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68462676fcbc8330a0069b76e9016f23