### PR TITLE
Fix markdownlint errors

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,3 @@
+MD013: false
+MD033: false
+MD034: false

--- a/README.md
+++ b/README.md
@@ -30,12 +30,14 @@ README Improver is a command-line interface (CLI) tool and GitHub Action that le
 Follow these steps to install README Improver:
 
 1. Create a virtual environment:
+
     ```bash
     python -m venv .venv
     source .venv/bin/activate  # For Windows: .venv\Scripts\activate
     ```
 
 2. Install required packages:
+
     ```bash
     pip install -r requirements.txt
     ```
@@ -45,6 +47,7 @@ Follow these steps to install README Improver:
 ## Usage
 
 Run the CLI tool within the repository containing a `README.md` file using the command:
+
 ```bash
 python run_improver.py
 ```
@@ -120,4 +123,4 @@ Thanks to OpenAI and the community for feedback.
 
 ## Contact
 
-- Email: hamzahabib10@gmail.com
+- Email: <hamzahabib10@gmail.com>

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -5,7 +5,7 @@
 **Purpose:** No module docstring
 **Key Functions:** None
 
-## readme_improver/**init**.py
+## `readme_improver/__init__.py`
 
 **Purpose:** Utilities for the ai-readme-improver package.
 **Key Functions:** None
@@ -90,7 +90,7 @@
 - main() -> None
 **Used in:** .github/workflows/auto-docs.yml
 
-## tests/**init**.py
+## `tests/__init__.py`
 
 **Purpose:** No module docstring
 **Key Functions:** None

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,17 +1,21 @@
 # Project Architecture
 
 ## main.py
+
 **Purpose:** No module docstring
 **Key Functions:** None
 
-## readme_improver/__init__.py
+## readme_improver/**init**.py
+
 **Purpose:** Utilities for the ai-readme-improver package.
 **Key Functions:** None
 
 ## readme_improver/improver.py
+
 **Purpose:** No module docstring
 **Key Functions:** load_config(), build_prompt(), generate_summary(), suggest_improvements(), rewrite_readme()
 **Inputs/Outputs:**
+
 - load_config(path) -> dict[str, Any] - Load configuration values from a YAML file.
 - build_prompt(readme_text, config) -> str - Construct the prompt for the rewrite request.
 - generate_summary(readme_text, model, prompt_prefix) -> str - Generate a TL;DR summary of the README.
@@ -20,83 +24,104 @@
 **Used in:** .github/workflows/readme-improver.yml
 
 ## readme_improver/logger.py
+
 **Purpose:** No module docstring
 **Key Functions:** get_logger()
 **Inputs/Outputs:**
+
 - get_logger() -> logging.Logger - Return a configured logger writing to file and console.
 
 ## readme_improver/openai_helper.py
+
 **Purpose:** No module docstring
 **Key Functions:** _get_client(), _estimate_cost(), ask_openai()
 **Inputs/Outputs:**
+
 - _get_client() -> 'OpenAI' - Create the OpenAI client lazily.
 - _estimate_cost(model, total_tokens) -> float - Estimate API cost for a given model and token count.
 - ask_openai(prompt, model, temperature, max_tokens) -> str - Send a prompt to OpenAI ChatCompletion with caching and detailed logging.
 
 ## readme_improver/post_comment.py
+
 **Purpose:** No module docstring
 **Key Functions:** get_pr_number(), main()
 **Inputs/Outputs:**
+
 - get_pr_number() -> str - Extract the pull request number from the GitHub event payload.
 - main() - Post README improvement suggestions as a PR comment.
 **Used in:** .github/workflows/readme-improver.yml
 
 ## readme_improver/readme_loader.py
+
 **Purpose:** No module docstring
 **Key Functions:** load_readme()
 **Inputs/Outputs:**
+
 - load_readme(path) -> str - Load the contents of a README file.
 
 ## run_improver.py
+
 **Purpose:** No module docstring
 **Key Functions:** main()
 **Inputs/Outputs:**
+
 - main(argv) - Run the CLI.
 **Used in:** .github/workflows/readme-improver.yml
 
 ## scripts/generate_architecture_md.py
+
 **Purpose:** No module docstring
 **Key Functions:** iter_python_files(), extract_module_info(), generate_markdown(), main()
 **Inputs/Outputs:**
+
 - iter_python_files() -> Iterable[Path] - Yield all relevant Python files within the repository.
 - extract_module_info(path, all_files)
 - generate_markdown(modules) -> str
 - main() -> None
 
 ## scripts/update_readme.py
+
 **Purpose:** No module docstring
 **Key Functions:** archive_previous(), generate_files(), main()
 **Inputs/Outputs:**
+
 - archive_previous(timestamp) -> Path - Move existing generated files into a timestamped archive directory.
 - generate_files(readme_text, cfg) -> None - Generate updated README, suggestions and save them.
 - main() -> None
 **Used in:** .github/workflows/auto-docs.yml
 
-## tests/__init__.py
+## tests/**init**.py
+
 **Purpose:** No module docstring
 **Key Functions:** None
 
 ## tests/test_improver.py
+
 **Purpose:** No module docstring
 **Key Functions:** dummy_ask(), test_generate_summary(), test_suggest_improvements(), test_rewrite_readme()
 **Inputs/Outputs:**
+
 - dummy_ask(prompt, model, temperature, max_tokens)
 - test_generate_summary(monkeypatch)
 - test_suggest_improvements(monkeypatch)
 - test_rewrite_readme(monkeypatch)
 
 ## tests/test_misc.py
+
 **Purpose:** No module docstring
 **Key Functions:** test_build_prompt(), test_load_config(), test_get_logger_singleton(), test_ask_openai_caching()
 **Inputs/Outputs:**
+
 - test_build_prompt()
 - test_load_config(tmp_path)
 - test_get_logger_singleton()
 - test_ask_openai_caching(tmp_path, monkeypatch)
 
 ## tests/test_readme_loader.py
+
 **Purpose:** No module docstring
 **Key Functions:** test_load_readme_not_found(), test_load_readme()
 **Inputs/Outputs:**
+
 - test_load_readme_not_found(tmp_path)
 - test_load_readme(tmp_path)

--- a/docs/workflow_instructions.md
+++ b/docs/workflow_instructions.md
@@ -9,6 +9,7 @@ The repository needs a workflow file (for example, `.github/workflows/improve_re
 - **Automatic trigger**: run whenever a pull request modifies `README.md` or `ai_readme_improver.py` so that improvements are always reviewed.
 - **Manual trigger**: enable `workflow_dispatch` so you can start a job through the Actions tab at any time.
 - **Workflow steps**: checkout the repo, set up Python, install requirements, run the script, and commit the updated README and logs if anything changed.
+
 ## 2. Logging in the Python Script
 
 - Accept `--input`, `--output`, and `--log-dir` arguments.
@@ -19,11 +20,12 @@ The repository needs a workflow file (for example, `.github/workflows/improve_re
 
 ## 3. Example Codex Prompts
 
-
 Example Codex prompts:
+
 - "Create the workflow file with auto and manual triggers that installs requirements, runs the improver, checks for changes, and pushes updates."
 - "Add logging in ai_readme_improver.py to record prompts, responses, timing, and usage."
 - "Describe how to manually run the workflow from the Actions tab."
+
 ## 4. Verifying End-to-End Execution
 
 1. **Local test**: Run `python ai_readme_improver.py --input README.md --output README.test.md --log-dir logs_test` with your OpenAI API key set. Confirm that `README.test.md` appears and a log file is written in `logs_test`.

--- a/oldreadme/2025-06-09-00-24/README.md
+++ b/oldreadme/2025-06-09-00-24/README.md
@@ -30,12 +30,14 @@ README Improver is a command-line interface (CLI) tool and GitHub Action that le
 Follow these steps to install README Improver:
 
 1. Create a virtual environment:
+
     ```bash
     python -m venv .venv
     source .venv/bin/activate  # For Windows: .venv\Scripts\activate
     ```
 
 2. Install required packages:
+
     ```bash
     pip install -r requirements.txt
     ```
@@ -45,6 +47,7 @@ Follow these steps to install README Improver:
 ## Usage
 
 Run the CLI tool within the repository containing a `README.md` file using the command:
+
 ```bash
 python run_improver.py
 ```
@@ -120,4 +123,4 @@ Thanks to OpenAI and the community for feedback.
 
 ## Contact
 
-- Email: hamzahabib10@gmail.com
+- Email: <hamzahabib10@gmail.com>

--- a/oldreadme/2025-06-09-00-24/suggestions.md
+++ b/oldreadme/2025-06-09-00-24/suggestions.md
@@ -1,0 +1,21 @@
+# 🤖 AI README Improver Feedback
+
+## TL;DR Summary
+
+TL;DR: README Improver is a CLI tool and GitHub Action that uses OpenAI to enhance README.md files by generating summaries, suggestions, and polished versions. It works locally or as a GitHub Action for automated feedback on pull requests.
+
+## Improvement Suggestions
+
+- Add a section for "Installation" with detailed steps on how to install the tool
+- Include a section for "Usage" with instructions on how to run the CLI tool
+- Create a section for "GitHub Action Setup" with a detailed guide on how to set up the tool as a GitHub Action
+- Consider adding a section for "Contributing" to encourage contributions
+- Include a section for "License" to specify the project's licensing information
+- Add a section for "Maintainers" to list the maintainers of the project
+- Consider adding a section for "Acknowledgements" to thank contributors or technologies used
+- Include a section for "Contact" to provide contact information for the project
+- Add badges for build status and license to provide more information at a glance
+- Use more SEO-friendly keywords in the README content, such as "README improvement tool", "GitHub Action", "Markdown styling", "OpenAI technology"
+
+---
+*Powered by [OpenAI](https://openai.com)*


### PR DESCRIPTION
## Summary
- add markdownlint configuration to disable some rules
- run markdownlint autofix across docs and README

## Testing
- `pytest -q`
- `markdownlint README.md docs/**/*.md`

------
https://chatgpt.com/codex/tasks/task_e_684628b820808330a3ec858406fea38f