### PR TITLE
Add CLI options for badges and extra sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,13 @@ Run the CLI tool within the repository containing a `README.md` file using the c
 python run_improver.py
 ```
 
+Optional flags:
+
+- `--logo PATH` – override the logo path or URL
+- `--email ADDRESS` – set the contact email
+- `--badge "Name,image_url,link"` – add a badge (repeatable)
+- `--extra-section "Title:Content"` – append a custom section (repeatable)
+
 After execution, `suggestions.md` and `README.improved.md` will be generated, providing feedback and an enhanced README version. Detailed logs are stored in `logs/run_YYYYMMDD_HHMMSS.log`, including OpenAI prompts, responses, costs, and timing details. In GitHub Actions, logs are uploaded as artifacts for retrieval.
 
 ### Quick Start

--- a/readme_improver/improver.py
+++ b/readme_improver/improver.py
@@ -46,6 +46,13 @@ def build_prompt(readme_text: str, config: dict[str, Any]) -> str:
     if config.get("email"):
         contact_section = f"## Contact\n- Email: {config['email']}"
 
+    badge_block = ""
+    if config.get("badges"):
+        badges = [
+            f"[![{b['name']}]({b['image_url']})]({b['link']})" for b in config["badges"]
+        ]
+        badge_block = " ".join(badges)
+
     sections = [
         f"## {s['title']}\n{s['content']}\n" for s in config.get("extra_sections", [])
     ]
@@ -55,12 +62,14 @@ def build_prompt(readme_text: str, config: dict[str, Any]) -> str:
 You are ChatGPT. Improve the project's README.md with these rules:
 1. Insert logo (if provided) at the very top:
    {logo_block}
-2. Include any extra sections specified in the config:
+2. Insert badges under the title:
+   {badge_block}
+3. Include any extra sections specified in the config:
    {extra_sections_md}
-3. Ensure a “Contact” section with the email is at the bottom:
+4. Ensure a “Contact” section with the email is at the bottom:
    {contact_section}
-4. Provide a short TL;DR summary and bullet-point suggestions, then output the fully-rewritten README.md.
-5. Only use maintainer names and other details explicitly provided in the config or current README. Do not invent additional data.
+5. Provide a short TL;DR summary and bullet-point suggestions, then output the fully-rewritten README.md.
+6. Only use maintainer names and other details explicitly provided in the config or current README. Do not invent additional data.
 
 Here is the current README.md:
 {readme_text}

--- a/run_improver.py
+++ b/run_improver.py
@@ -28,6 +28,20 @@ def main(argv=None):
     parser.add_argument("--improved", default="README.improved.md", help="Improved README output file")
     parser.add_argument("--config", default="config.yaml", help="Path to config file")
     parser.add_argument("--model", default="gpt-3.5-turbo", help="OpenAI model")
+    parser.add_argument("--logo", help="Path or URL for a project logo")
+    parser.add_argument("--email", help="Contact email address for the README")
+    parser.add_argument(
+        "--badge",
+        action="append",
+        metavar="SPEC",
+        help="Badge spec 'name,image_url,link' (repeatable)",
+    )
+    parser.add_argument(
+        "--extra-section",
+        action="append",
+        metavar="SPEC",
+        help="Extra section 'Title:Content' (repeatable)",
+    )
     parser.add_argument("--verbose", action="store_true", help="Enable verbose logging")
     args = parser.parse_args(argv)
 
@@ -41,6 +55,34 @@ def main(argv=None):
     env_logo = os.getenv("README_LOGO")
     if env_logo:
         config["logo_path"] = env_logo
+
+    if args.logo:
+        config["logo_path"] = args.logo
+    if args.email:
+        config["email"] = args.email
+
+    if args.badge:
+        badges = []
+        for spec in args.badge:
+            parts = [p.strip() for p in spec.split(",")]
+            if len(parts) == 3:
+                badges.append({"name": parts[0], "image_url": parts[1], "link": parts[2]})
+            else:
+                logger.warning("Ignoring invalid badge spec: %s", spec)
+        if badges:
+            config["badges"] = badges
+
+    if args.extra_section:
+        extras = []
+        for spec in args.extra_section:
+            if ":" in spec:
+                title, content = spec.split(":", 1)
+                extras.append({"title": title.strip(), "content": content.strip()})
+            else:
+                logger.warning("Ignoring invalid extra section spec: %s", spec)
+        if extras:
+            config.setdefault("extra_sections", [])
+            config["extra_sections"].extend(extras)
 
     if not os.getenv("OPENAI_API_KEY"):
         logger.error("OPENAI_API_KEY is not set. Add it to your .env file.")

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -39,11 +39,15 @@ def test_build_prompt():
         "logo_path": "logo.png",
         "email": "a@b.com",
         "extra_sections": [{"title": "More", "content": "Stuff"}],
+        "badges": [
+            {"name": "CI", "image_url": "img.png", "link": "https://ci"}
+        ],
     }
     prompt = build_prompt("readme", cfg)
     assert "logo.png" in prompt
     assert "## Contact" in prompt
     assert "More" in prompt
+    assert "img.png" in prompt
 
 
 def test_load_config(tmp_path):


### PR DESCRIPTION
## Summary
- support new CLI options `--logo`, `--email`, `--badge` and `--extra-section`
- parse the new flags into the configuration for `build_prompt`
- include badges when building README rewrite prompt
- document the optional flags
- adjust tests for updated prompt building

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846450fe6288330954ff7c222b51c29