### PR TITLE
Add JSON logging for OpenAI requests

### DIFF
--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -83,7 +83,9 @@ Returns: `float` cost in USD.
 
 ## readme_improver.openai_helper.ask_openai
 
-Send a prompt to OpenAI ChatCompletion with caching and detailed logging.
+Send a prompt to OpenAI ChatCompletion with caching. Each call writes the
+prompt, response, usage statistics and elapsed time to `logs/<timestamp>.json`.
+On errors the stack trace is saved to `logs/<timestamp>_error.json`.
 
 | Name | Type | Description |
 | --- | --- | --- |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -39,7 +39,7 @@
 
 - _get_client() -> 'OpenAI' - Create the OpenAI client lazily.
 - _estimate_cost(model, total_tokens) -> float - Estimate API cost for a given model and token count.
-- ask_openai(prompt, model, temperature, max_tokens) -> str - Send a prompt to OpenAI ChatCompletion with caching and detailed logging.
+- ask_openai(prompt, model, temperature, max_tokens) -> str - Send a prompt to OpenAI ChatCompletion with caching. Writes request and response details to JSON files under `logs/`.
 
 ## readme_improver/post_comment.py
 


### PR DESCRIPTION
## Summary
- log each prompt and response to `logs/<timestamp>.json`
- record stack traces to `logs/<timestamp>_error.json`
- document new logging behaviour

## Testing
- `flake8 readme_improver/openai_helper.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846451153608330ad97df479db10b36