### PR TITLE
Implement config validation

### DIFF
--- a/run_improver.py
+++ b/run_improver.py
@@ -11,6 +11,7 @@ from readme_improver.improver import (
     suggest_improvements,
     rewrite_readme,
     load_config,
+    validate_config,
 )
 from readme_improver.logger import get_logger
 
@@ -18,7 +19,7 @@ from readme_improver.logger import get_logger
 logger = get_logger()
 
 
-def main(argv=None):
+def main(argv=None) -> int:
     """Run the CLI."""
     sys.stdout.reconfigure(encoding="utf-8")
 
@@ -42,19 +43,22 @@ def main(argv=None):
     if env_logo:
         config["logo_path"] = env_logo
 
+    if not validate_config(config):
+        return 1
+
     if not os.getenv("OPENAI_API_KEY"):
         logger.error("OPENAI_API_KEY is not set. Add it to your .env file.")
-        return
+        return 1
 
     readme_path = args.readme
     if not os.path.exists(readme_path):
         logger.error("❌ Error: %s not found.", readme_path)
-        return
+        return 1
 
     readme_text = load_readme(readme_path)
     if not readme_text.strip():
         logger.warning("⚠️ README is empty. Exiting.")
-        return
+        return 0
 
     logger.info("🔹 Generating TL;DR summary...")
     summary = generate_summary(readme_text, args.model)
@@ -78,7 +82,8 @@ def main(argv=None):
     with open(args.improved, "w", encoding="utf-8") as f:
         f.write(improved)
     logger.info("✅ Saved improved version to %s\n", args.improved)
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/tests/test_improver.py
+++ b/tests/test_improver.py
@@ -2,6 +2,7 @@ from readme_improver.improver import (
     generate_summary,
     suggest_improvements,
     rewrite_readme,
+    validate_config,
 )
 
 
@@ -25,3 +26,21 @@ def test_rewrite_readme(monkeypatch):
     monkeypatch.setattr("readme_improver.improver.ask_openai", dummy_ask)
     result = rewrite_readme("Readme")
     assert "RESPONSE" in result
+
+
+def test_validate_config(tmp_path):
+    logo = tmp_path / "logo.png"
+    logo.write_text("img", encoding="utf-8")
+    cfg = {
+        "project_name": "P",
+        "email": "a@b.com",
+        "logo_path": str(logo),
+        "badges": [{"name": "b", "image_url": "i", "link": "l"}],
+        "extra_sections": [{"title": "t", "content": "c"}],
+    }
+    assert validate_config(cfg)
+
+
+def test_validate_config_missing(tmp_path):
+    cfg = {"logo_path": str(tmp_path / "missing.png")}
+    assert not validate_config(cfg)


### PR DESCRIPTION
## Summary
- validate configuration with helpful logging
- check validation in CLI entry point
- add tests for validator

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68464512d5888330a8ab45aa4736e294