### PR TITLE
Add archive and artifact steps to readme workflow

### DIFF
--- a/.github/workflows/readme-improver.yml
+++ b/.github/workflows/readme-improver.yml
@@ -20,19 +20,34 @@ jobs:
         with:
           python-version: "3.10"
       - run: pip install -r requirements.txt
+      - name: Archive previous README
+        run: |
+          timestamp=$(date -u +"%Y-%m-%d-%H-%M")
+          mkdir -p oldreadme/$timestamp
+          if [ -f README.md ]; then mv README.md oldreadme/$timestamp/; fi
+          if [ -f README.improved.md ]; then mv README.improved.md oldreadme/$timestamp/; fi
+          if [ -f suggestions.md ]; then mv suggestions.md oldreadme/$timestamp/; fi
+          echo "ARCHIVE_DIR=oldreadme/$timestamp" >> "$GITHUB_ENV"
       - name: Run Improver
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-        run: python run_improver.py --config readme-improver.config.yaml
+        run: python run_improver.py --config readme-improver.config.yaml --readme "$ARCHIVE_DIR/README.md"
       - run: mv README.improved.md README.md
       - name: Commit results
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add README.md README.improved.md suggestions.md
+          git add README.md README.improved.md suggestions.md oldreadme/ logs/
           git diff --cached --quiet || git commit -m "Auto update README"
           git push origin HEAD:${{ github.head_ref || github.ref_name }}
       - if: github.event_name == 'pull_request'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: python post_comment.py
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: readme-improver-artifacts
+          path: |
+            logs/
+            suggestions.md

--- a/logs/run_20250609_022250.log
+++ b/logs/run_20250609_022250.log
@@ -1,0 +1,14 @@
+02:22:50 - 
+----- OpenAI Request -----
+02:22:50 - Model: test | Temperature: 0.5 | Max tokens: 1280
+02:22:50 - Prompt:
+hi
+02:22:50 - Tokens: prompt=1 completion=1 total=2
+02:22:50 - Estimated cost: $0.000000
+02:22:50 - Finish reason: stop
+02:22:50 - Elapsed time: 0.00s
+02:22:50 - Response:
+answer
+02:22:50 - ----- End Request -----
+
+02:22:50 - /tmp/pytest-of-root/pytest-0/test_load_readme_not_found0/missing.md not found.


### PR DESCRIPTION
## Summary
- archive README and related files before running improver
- commit generated logs along with README history
- upload `logs/` and `suggestions.md` as artifacts

## Testing
- `pytest -q`
- `flake8`

------
https://chatgpt.com/codex/tasks/task_e_68464515b3a08330aea5ca66c6e97541