### PR TITLE
Implement Awesome README template

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -3,15 +3,38 @@ email: "hamzahabib10@gmail.com"
 logo_path: "assets/logo.png"
 badges:
   - name: "Build Status"
-    image_url: "https://img.shields.io/github/actions/workflow/status/username/repo/ci.yml"
+    image_url: "https://img.shields.io/github/actions/workflow/status/habib13352/ai-readme-improver/ci.yml"
     link: "https://github.com/habib13352/ai-readme-improver/actions"
+  - name: "License"
+    image_url: "https://img.shields.io/badge/license-MIT-blue.svg"
+    link: "LICENSE"
+
 extra_sections:
+  - title: "Table of Contents"
+    content: "<!-- TOC -->"
+  - title: "Demo"
+    content: "![Demo](assets/demo.gif)"
+  - title: "Installation"
+    content: |
+      ```bash
+      pip install ai-readme-improver
+      ```
+  - title: "Usage"
+    content: |
+      ```bash
+      ai-readme-improver --help
+      ```
+  - title: "Contributing"
+    content: "See [CONTRIBUTING.md](CONTRIBUTING.md)."
+  - title: "License"
+    content: >
+      This project is licensed under the MIT License — see the [LICENSE](LICENSE) file.
   - title: "Maintainers"
     content: |
-      - Hamza Habib (@habib13352)
+      - Hamza Ali Habib (@habib13352)
   - title: "Acknowledgements"
     content: |
-      Thanks to OpenAI and the community for feedback.
+      - Thanks to the OpenAI team and community.
 sections:
   - name: Badges
     prompt_file: prompts/update_badges.prompt

--- a/readme_improver/improver.py
+++ b/readme_improver/improver.py
@@ -9,6 +9,22 @@ import yaml
 
 from .openai_helper import ask_openai
 
+# System prompt guiding the README structure
+README_ORDER_MESSAGE = (
+    "Structure the README exactly in this order, using these section headings "
+    "(with Markdown H2):\n\n"
+    "Title & Logo\n\n"
+    "Badges\n\n"
+    "Table of Contents\n\n"
+    "Demo\n\n"
+    "Installation\n\n"
+    "Usage\n\n"
+    "Contributing\n\n"
+    "License\n\n"
+    "Maintainers\n\n"
+    "Acknowledgements"
+)
+
 
 def load_config(path: str = "config.yaml") -> dict[str, Any]:
     """Load configuration values from a YAML file.
@@ -156,4 +172,8 @@ def rewrite_readme(
         prompt = build_prompt(readme_text, config)
     else:
         prompt = (prompt_prefix or DEFAULT_REWRITE_PROMPT) + readme_text
+
+    # Prepend the system-level guidance about README structure
+    prompt = f"{README_ORDER_MESSAGE}\n\n{prompt}"
+
     return ask_openai(prompt, model=model, temperature=0.7, max_tokens=1920)


### PR DESCRIPTION
## Summary
- implement README ordering prompt to guide OpenAI
- replace default badges and sections in `config.yaml`

## Testing
- `python run_improver.py --config config.yaml --archive-dir oldreadme`

------
https://chatgpt.com/codex/tasks/task_e_6846637088008330be795f1359142eca